### PR TITLE
refactor: Grab global user name and reversed message order

### DIFF
--- a/nemli/commands/utility/summarize.py
+++ b/nemli/commands/utility/summarize.py
@@ -36,8 +36,8 @@ async def summarize_command(
         messages = await channel.history(limit=message_count).flatten()  # type: ignore
         messages_content = "\n".join(
             [
-                f"{msg.author}: {clean_up_stopwords(msg.content)}"
-                for msg in messages
+                f"**{msg.author.global_name or msg.author.name}**: {clean_up_stopwords(msg.content)}"
+                for msg in reversed(messages)
                 if msg.content and msg.author != bot.user
             ]
         )  # Here we are creating a string with the content of the last 100 messages


### PR DESCRIPTION
Essa PR faz duas coisas:
 - Ao invés de pegar o handler do usuário `@` pega seu nome global, caso este esteja vazio (`None`) vai pegar o username padrão definido no server.
 - Reverte as mensagens (isso não impacta o ChatGPT diretamente), entretanto o discord manda as mensagens na ordem reversa do que a conversa ocorre no chat principal (estou dando um `reversed` do python para organizar).

Addresses:
 - Closes #17 