### PR TITLE
feature: Get last bot message and link it instead of doing a new summary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Vscode
+.vscode/

--- a/nemli/nlp/messages.py
+++ b/nemli/nlp/messages.py
@@ -1,11 +1,15 @@
 from functools import lru_cache
+from typing import Optional
 
 from nltk import word_tokenize
 from nltk.corpus import stopwords
 
 
 @lru_cache(maxsize=1024)
-def clean_up_stopwords(message: str) -> str:
+def clean_up_stopwords(message: Optional[str] = None) -> str:
+    if not (message and isinstance(message, str)):
+        return ""
+
     stop_words = set(stopwords.words("portuguese")) - set(["que", "não", "eu", "ele", "ela"])
     tokens = word_tokenize(message)
-    return " ".join(token for token in tokens if token.lower() not in stop_words)
+    return " ".join(token for token in tokens if token.lower() not in stop_words).strip()

--- a/nemli/schemas/messages.py
+++ b/nemli/schemas/messages.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass(frozen=True, slots=True)
+class Message:
+    id: int
+    position: int
+    author: str
+    content: str
+    jump_url: str
+    created_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class ParserDiscordMessages:
+    messages: Optional[list[Message]]
+    bot_message: Optional[Message]

--- a/nemli/services/messages.py
+++ b/nemli/services/messages.py
@@ -1,0 +1,37 @@
+from typing import Optional
+
+from nextcord import ClientUser
+from nextcord import Message as DiscordMessage
+
+from nemli.nlp.messages import clean_up_stopwords
+from nemli.schemas.messages import Message, ParserDiscordMessages
+
+
+def parse_discord_messages(
+    user_bot: Optional[ClientUser] = None,
+    messages: Optional[list[DiscordMessage]] = None,
+) -> ParserDiscordMessages:
+    if not (user_bot and messages):
+        return ParserDiscordMessages(messages=None, bot_message=None)
+
+    parsed_messages, bot_message = [], None
+    for i, msg in enumerate(messages):
+        is_bot_message = msg.author == user_bot
+
+        message = None
+        if message_content := msg.content:
+            message = Message(
+                id=msg.id,
+                position=i + 1,
+                author=f"**{msg.author.global_name or msg.author.name}**",
+                content=clean_up_stopwords(message_content),
+                jump_url=msg.jump_url,
+                created_at=msg.created_at,
+            )
+
+        if is_bot_message and message:
+            bot_message = message
+        elif not is_bot_message and message:
+            parsed_messages.append(message)
+    # Here we are creating a string with the content of the last N messages
+    return ParserDiscordMessages(messages=parsed_messages, bot_message=bot_message)

--- a/tests/extras/mocks.py
+++ b/tests/extras/mocks.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+from random import randint
+from unittest.mock import MagicMock
+
+from nextcord import ClientUser
+from nextcord import Message as DiscordMessage
+
+CREATED_AT = datetime.now()
+
+
+def mock_discord_client_user(obj_id: int = randint(1_000_000, 10_000_000)):
+    mock = MagicMock(spec=ClientUser)
+    mock.id = obj_id
+    mock.global_name = "Mock"
+    return mock
+
+
+def mock_discord_message(obj_id: int = randint(1_000_000, 10_000_000), author=None):
+    mock = MagicMock(spec=DiscordMessage)
+    mock.id = obj_id
+    mock.author = author
+    mock.content = f"Message {obj_id}"
+    mock.jump_url = f"https://discord.com/channels/{obj_id}/{obj_id}/{obj_id}"
+    mock.created_at = CREATED_AT
+    return mock

--- a/tests/test_parsed_discord_messages.py
+++ b/tests/test_parsed_discord_messages.py
@@ -1,0 +1,58 @@
+import pytest
+
+from nemli.schemas.messages import Message, ParserDiscordMessages
+from nemli.services.messages import parse_discord_messages
+from tests.extras.mocks import (
+    CREATED_AT,
+    mock_discord_client_user,
+    mock_discord_message,
+)
+
+DEFAULT_OBJ_ID = 100_000
+
+BOT_USER = mock_discord_client_user(obj_id=DEFAULT_OBJ_ID)
+DEFAULT_USER = mock_discord_client_user(obj_id=1_000_001)
+
+
+@pytest.mark.parametrize(
+    "user_bot, messages, parsed",
+    [
+        (None, None, {"messages": None, "bot_message": None}),
+        (
+            BOT_USER,
+            [mock_discord_message(obj_id=DEFAULT_OBJ_ID, author=BOT_USER)],
+            {
+                "messages": [],
+                "bot_message": Message(
+                    id=DEFAULT_OBJ_ID,
+                    position=1,
+                    author="**Mock**",
+                    content=f"Message {DEFAULT_OBJ_ID}",
+                    jump_url=f"https://discord.com/channels/{DEFAULT_OBJ_ID}/{DEFAULT_OBJ_ID}/{DEFAULT_OBJ_ID}",
+                    created_at=CREATED_AT,
+                ),
+            },
+        ),
+        (
+            mock_discord_client_user(obj_id=BOT_USER),
+            [mock_discord_message(obj_id=1_000_001, author=DEFAULT_USER)],
+            {
+                "messages": [
+                    Message(
+                        id=1_000_001,
+                        position=1,
+                        author="**Mock**",
+                        content=f"Message {1_000_001}",
+                        jump_url=f"https://discord.com/channels/{1_000_001}/{1_000_001}/{1_000_001}",
+                        created_at=CREATED_AT,
+                    )
+                ],
+                "bot_message": None,
+            },
+        ),
+    ],
+)
+def test_parse_discord_messages(user_bot, messages, parsed: dict):
+    parsed_discord_messages: ParserDiscordMessages = parse_discord_messages(user_bot=user_bot, messages=messages)
+    assert parsed_discord_messages.messages == parsed.get("messages", None)
+    assert parsed_discord_messages.bot_message == parsed.get("bot_message", None)

--- a/tests/test_stopwords.py
+++ b/tests/test_stopwords.py
@@ -18,6 +18,8 @@ from nemli.nlp.messages import clean_up_stopwords
             "A vantagem de ter péssima memória é divertir-se muitas vezes com as mesmas coisas boas como se fosse a primeira vez.",
             "vantagem ter péssima memória divertir-se muitas vezes mesmas coisas boas primeira vez .",
         ),
+        ("", ""),
+        (None, ""),
     ],
 )
 def test_clean_up_stopwords(message: str, expected: str):


### PR DESCRIPTION
Essa alteração de certa forma altera a forma como as mensagens são lidas ... portanto existe a possibilidade de quebrar o bot.
Dito isso, é verificado se a mensagem de resumo do bot já existe dentro do total de mensagens retornadas, se existir ao invés de gerar um novo resumo, é gerada uma mensagem para o último resumo já criado pelo bot.

Addresses:

 - Closes #17 
 - Closes #18 