### PR TITLE
fix: Correct grab the SERVER PROFILE nickname for the user

### DIFF
--- a/nemli/__init__.py
+++ b/nemli/__init__.py
@@ -1,10 +1,11 @@
 # Initialize bot instance
-from nextcord.ext import commands
 import nextcord
+from nextcord.ext import commands
 
 intents = nextcord.Intents.default()
 # Enable message content intent, this is important for the bot to be able to respond to messages
 intents.message_content = True
+intents.members = True
 bot = commands.Bot(
     command_prefix="!",
     intents=intents,

--- a/nemli/services/messages.py
+++ b/nemli/services/messages.py
@@ -14,6 +14,13 @@ def is_summary_link_message(message_content: str) -> bool:
     return message_content.lower().startswith("nemli:")
 
 
+def get_member_name(msg: DiscordMessage) -> str:
+    author_name = msg.author.global_name or msg.author.name
+    if (guild := msg.guild) and (member := guild.get_member(msg.author.id)):
+        return member.nick or author_name or member.display_name
+    return author_name
+
+
 def parse_discord_messages(
     user_bot: Optional[ClientUser] = None,
     messages: Optional[list[DiscordMessage]] = None,
@@ -27,11 +34,12 @@ def parse_discord_messages(
 
         message = None
         if message_content := msg.content:
+            author = get_member_name(msg)
             content = clean_up_stopwords(message_content) if settings.remove_stopwords else message_content
             message = Message(
                 id=msg.id,
                 position=i + 1,
-                author=f"**{msg.author.global_name or msg.author.name}**",
+                author=f"**{author}**",
                 content=content,
                 jump_url=msg.jump_url,
                 created_at=msg.created_at,

--- a/tests/extras/mocks.py
+++ b/tests/extras/mocks.py
@@ -8,9 +8,17 @@ from nextcord import Message as DiscordMessage
 CREATED_AT = datetime.now()
 
 
+def mock_discord_guild(obj_id: int = randint(1_000_000, 10_000_000)):
+    mock = MagicMock()
+    mock.id = obj_id
+    mock.get_member = lambda user_id: mock_discord_client_user(1_000_001)
+    return mock
+
+
 def mock_discord_client_user(obj_id: int = randint(1_000_000, 10_000_000)):
     mock = MagicMock(spec=ClientUser)
     mock.id = obj_id
+    mock.nick = "Mock"
     mock.global_name = "Mock"
     return mock
 
@@ -19,6 +27,7 @@ def mock_discord_message(obj_id: int = randint(1_000_000, 10_000_000), author=No
     mock = MagicMock(spec=DiscordMessage)
     mock.id = obj_id
     mock.author = author
+    mock.guild = mock_discord_guild(obj_id=obj_id)
     mock.content = f"Message {obj_id}"
     mock.jump_url = f"https://discord.com/channels/{obj_id}/{obj_id}/{obj_id}"
     mock.created_at = CREATED_AT

--- a/tests/services/test_messages.py
+++ b/tests/services/test_messages.py
@@ -1,8 +1,11 @@
 import pytest
 
 from nemli.schemas.messages import Message, ParserDiscordMessages
-from nemli.services.messages import parse_discord_messages
-from nemli.services.messages import is_summary_link_message
+from nemli.services.messages import (
+    get_member_name,
+    is_summary_link_message,
+    parse_discord_messages,
+)
 from tests.extras.mocks import (
     CREATED_AT,
     mock_discord_client_user,
@@ -53,7 +56,7 @@ DEFAULT_USER = mock_discord_client_user(obj_id=1_000_001)
         ),
     ],
 )
-def test_parse_discord_messages(user_bot, messages, parsed: dict):
+def test_parse_discord_messages(setup_nltk_stopwords, user_bot, messages, parsed: dict):
     parsed_discord_messages: ParserDiscordMessages = parse_discord_messages(user_bot=user_bot, messages=messages)
     assert parsed_discord_messages.messages == parsed.get("messages", None)
     assert parsed_discord_messages.bot_message == parsed.get("bot_message", None)
@@ -68,3 +71,8 @@ def test_is_summary_link_message_detect_link_summary():
 Nemli: Um resumo já foi criado recentemente, e se encontra em 29/100: ...
 """
     assert is_summary_link_message(msg) is True
+
+
+def test_get_member_name():
+    msg = mock_discord_message(obj_id=DEFAULT_OBJ_ID, author=DEFAULT_USER)
+    assert get_member_name(msg) == "Mock"


### PR DESCRIPTION
Essa PR deve corrigir o nome dos usuários passados ao bot.

Para pegar o `nickname` de cada usuário definido no servidor do Discord, é necessário buscar pelos membros dentro da `guild`, por padrão as mensagens retornam o objeto `nextcord.User`, mas é necessário inspecionar o `nextcord.Member`.

Essa PR tb faz alguns ajustes nos testes (como renomear um dos arquivos de teste que estavam sem `test_` no começo do nome).


Addresses:
  - Closes #58 