### PR TITLE
Declare python 3.13 unsupported at pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "nltk>=3.8.1",
     "loguru>=0.7.2",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.13"
 readme = "README.md"
 license = { text = "MIT" }
 


### PR DESCRIPTION
Related #60